### PR TITLE
Feature-Implement json handle in fetch API

### DIFF
--- a/app/js/ui/AppVC.js
+++ b/app/js/ui/AppVC.js
@@ -85,16 +85,27 @@ export default class AppVC extends React.Component {
     }
 
     @autobind
-    _showStyles(...args) {
-        try {
-            var styles = JSON.stringify(args[0]['body']);
-            App.events.publish('ui.requestModal', {
-                title: 'Styles of Beers',
-                message: styles
-            });
-        } catch(e) {
-            throw new Error('Could not parse styles of beer. Shame.');
-        }
+    _showStyles(response) {
+        response.json().then(function(json) {
+            // Try catch in place mainly for errors in the data manipulation
+            try {
+                var stylesData = json.data,
+                    styles = [];
+
+                stylesData.forEach((beer) => {
+                    styles.push(beer.shortName ? beer.shortName : beer.name);
+                });
+                styles.sort();
+
+                // TODO - Display these beers differently
+                App.events.publish('ui.requestModal', {
+                    title: 'Styles of Beers',
+                    message: styles.join(', ')
+                });
+            } catch(e) {
+                throw new Error('Could not parse styles of beer. Shame.');
+            }
+        });
     }
 
     _handleFetchError(error) {


### PR DESCRIPTION
Glad to have gotten the API proxy endpoint working.
A few things:
- Maybe all this code doesn't belong in _showStyles?
- If most (if not all) our API endpoints are going to return JSON is there a way we can set up the code to reuse the `response.json().then()` pattern?
- We have the beer styles dropdown in the create account form but what if it were more like this modal and each word was styled like a tag but was actually a checkbox? - That way a user has more real estate/a frienly way to select and deselect styles when editing their account?

Any other comments UX or code related are very much welcome!

:)
